### PR TITLE
get awsAccountId from topicArn

### DIFF
--- a/driver.js
+++ b/driver.js
@@ -36,7 +36,7 @@ exports.handler = function(event, context) {
             data['awsRegion'] = arn[3];
             data['message'] = message;
         } else {
-            var subject = record.Sns.Subject;
+            var topicArn = record.Sns.TopicArn.split(':');
             data['record'] = record;
             data['message'] = message;
             data['awsAccountId'] = topicArn[4];

--- a/driver.js
+++ b/driver.js
@@ -39,8 +39,8 @@ exports.handler = function(event, context) {
             var subject = record.Sns.Subject;
             data['record'] = record;
             data['message'] = message;
-            data['awsAccountId'] = getAccountIdFromSubject(subject);
-            data['awsRegion'] = getAwsRegionFromSubject(subject);
+            data['awsAccountId'] = topicArn[4];
+            data['awsRegion'] = topicArn[3];
         }
     }
 
@@ -491,16 +491,6 @@ function isRegionInScope(awsRegion, regions) {
         }
     }
     return false;
-}
-
-function getAccountIdFromSubject(subject) {
-    "use strict";
-    return subject.match(/Account (\d{12})$/)[1];
-}
-
-function getAwsRegionFromSubject(subject) {
-    "use strict";
-    return subject.match(/^\[AWS Config:(.*?)\]/)[1];
 }
 
 function getS3Endpoint(region) {


### PR DESCRIPTION
sns subject is only allowed 100 characters and accountId is often truncated. Pulling awsAccountId from topicArn since it comes from same account the driver lambda lives. Also set awsRegion in same manner.

SAMPLE.. "Subject": "[AWS Config:us-east-1] AWS::AutoScaling::AutoScalingGroup mjsinflux-sit-2018060119280320090000000...",