### PR TITLE
update node runtime to 10.x due to EOL for node 8

### DIFF
--- a/configuration/cloudformation/ci_lambda_checks.template
+++ b/configuration/cloudformation/ci_lambda_checks.template
@@ -606,7 +606,7 @@
                         ]
                     }
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": "60"
             }
         },
@@ -707,7 +707,7 @@
                         ]
                     }
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": "60"
             },
             "DependsOn": [
@@ -1010,7 +1010,7 @@
                         ]
                     }
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": "300"
             },
             "DependsOn": [
@@ -1292,7 +1292,7 @@
                         ]
                     }
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": "300"
             },
             "DependsOn": [

--- a/deployment/setup.js
+++ b/deployment/setup.js
@@ -148,7 +148,7 @@ function deployRegion(params, logger, callback) {
                     description:    "CloudInsight Custom Checks Driver",
                     handler:        defaultDriverHandlerName,
                     roleName:       defaultLambdaRoleName,
-                    runtime:        'nodejs8.10',
+                    runtime:        'nodejs10.x',
                     timeout:        300,
                     subscribe:      true,
                     zipFile:        code
@@ -158,7 +158,7 @@ function deployRegion(params, logger, callback) {
                     description:    "CloudInsight Custom Checks Worker",
                     handler:        defaultWorkerHandlerName,
                     roleName:       defaultLambdaRoleName,
-                    runtime:        'nodejs8.10',
+                    runtime:        'nodejs10.x',
                     timeout:        300,
                     subscribe:      false,
                     zipFile:        code


### PR DESCRIPTION
Node 8 is near EOL for AWS lambdas, updating to 10.x